### PR TITLE
Fix SpriteBatch instantiation

### DIFF
--- a/src/tiled/Objectlayer.js
+++ b/src/tiled/Objectlayer.js
@@ -88,7 +88,7 @@ function Objectlayer(game, map, layer, index) {
     this.bodies = [];
 
     if (this.properties.batch) {
-        this.container = this.addChild(new Phaser.SpriteBatch());
+        this.container = this.addChild(new Phaser.SpriteBatch(game));
     } else {
         this.container = this;
     }

--- a/src/tiled/Tilelayer.js
+++ b/src/tiled/Tilelayer.js
@@ -166,7 +166,7 @@ function Tilelayer(game, map, layer, index) {
 
     // if batch is true, store children in a spritebatch
     if (this.properties.batch) {
-        this.container = this.addChild(new Phaser.SpriteBatch());
+        this.container = this.addChild(new Phaser.SpriteBatch(game));
     } else {
         this.container = this;
     }


### PR DESCRIPTION
SpriteBatch requires the `game` instance to be passed into the
constructor.  I am guessing this was a recent API change since I am
using Phaser 2.2.1.
