### PR TITLE
.apha => alpha

### DIFF
--- a/src/tiled/Tilemap.js
+++ b/src/tiled/Tilemap.js
@@ -170,7 +170,7 @@ function Tilemap(game, key, group) {
                 lyr = game.add.sprite(ldata.x, ldata.y, utils.cacheKey(key, 'layer', ldata.name), null, this);
 
                 lyr.visible = ldata.visible;
-                lyr.apha = ldata.opacity;
+                lyr.alpha = ldata.opacity;
 
                 this.images.push(lyr);
                 break;

--- a/src/tiled/Tilemap.js
+++ b/src/tiled/Tilemap.js
@@ -167,7 +167,9 @@ function Tilemap(game, key, group) {
                 break;
 
             case 'imagelayer':
-                lyr = game.add.sprite(ldata.x, ldata.y, utils.cacheKey(key, 'layer', ldata.name), null, this);
+                var x = ldata.x ? ldata.x : ldata.offsetx;
+				var y = ldata.y ? ldata.y : ldata.offsety;
+                lyr = game.add.sprite(x, y, utils.cacheKey(key, 'layer', ldata.name), null, this);
 
                 lyr.visible = ldata.visible;
                 lyr.alpha = ldata.opacity;


### PR DESCRIPTION
Guess this will fix it.
PS: I don't want to place a feature request here but it has been bugging me that tiled (mapeditor) does not support scaling on imagelayer's. I fixed this at my own implementation with an own property scaleX/scaleY. Maybe something like this could be as well implemented at this particular spot (after line 173) into phaser-tiled. For example: I do have rocks in my game, which are images not tiles, still I want them in different sizes without using multiple images.
