### PR TITLE
The scale was not being reset when resetting tiles.

### DIFF
--- a/src/tiled/Tilelayer.js
+++ b/src/tiled/Tilelayer.js
@@ -363,6 +363,8 @@ Tilelayer.prototype._resetTile = function (tile, x, y, tileId, tileset) {
     var blendMode = props.blendMode || this.properties.blendMode;
 
     tile.reset(x, y);
+    tile.scale.x = 1;
+    tile.scale.y = 1;
 
     tile.setTexture(texture);
 


### PR DESCRIPTION
This could cause some weird texture glitches.