### PR TITLE
Revert "The scale was not being reset when resetting tiles."

### DIFF
--- a/src/tiled/Tilelayer.js
+++ b/src/tiled/Tilelayer.js
@@ -363,8 +363,6 @@ Tilelayer.prototype._resetTile = function (tile, x, y, tileId, tileset) {
     var blendMode = props.blendMode || this.properties.blendMode;
 
     tile.reset(x, y);
-    tile.scale.x = 1;
-    tile.scale.y = 1;
 
     tile.setTexture(texture);
 


### PR DESCRIPTION
Reverts englercj/phaser-tiled#63

So I just noticed this was already fixed in this pull request. https://github.com/englercj/phaser-tiled/pull/59 So now it's double fixed. So I recommend reverting my change and keeping the old one.

I should have checked if it was already fixed in a new version. Sorry for the inconvenience.