### PR TITLE
Option to obey Tiled's renderorder. 

### DIFF
--- a/src/tiled/Tilemap.js
+++ b/src/tiled/Tilemap.js
@@ -64,6 +64,16 @@ function Tilemap(game, key, group) {
     this.orientation = data.orientation;
 
     /**
+     * @property {string} renderorder - The renderorder of the map
+     */
+    this.renderorder = data.renderorder;
+
+    /**
+     * @property {boolean} obeyRenderorder - If true then the map's renderorder will be obeyed.  Defaults to false.
+     */
+    this.obeyRenderorder = false;
+
+    /**
      * @property {number} format - The format of the map data, either Phaser.Tilemap.CSV or Phaser.Tilemap.TILED_JSON.
      */
     this.format = data.format;

--- a/src/tiled/TilemapParser.js
+++ b/src/tiled/TilemapParser.js
@@ -113,6 +113,7 @@ var TilemapParser = {
             tilewidth: parseInt(mapElement.attributes.getNamedItem('tilewidth').value, 10),
             tileheight: parseInt(mapElement.attributes.getNamedItem('tileheight').value, 10),
             orientation: mapElement.attributes.getNamedItem('orientation').value,
+            renderorder: mapElement.attributes.getNamedItem('renderorder').value,
             format: Phaser.Tilemap.TILED_XML,
             properties: {},
             layers: [],


### PR DESCRIPTION
Sorts tiles based on the renderorder given by Tiled if the map's obeyRenderorder is set (defaults to false).  

Allows for 2.5d maps, or maps with oversized tiles.

Does impact performance if enabled.

As an aside, I happened to notice that the tilelayer always adds children to itself as if it was always going to have tiles covering the screen, which isn't the case with sparse maps, which could make quite a speed difference for a sorted sparse map. 

I'd hope to have a more advanced sorting method eventually, this is just to enable the functionality. 