### PR TITLE
load the animation for the animated tile

### DIFF
--- a/src/tiled/Tileset.js
+++ b/src/tiled/Tileset.js
@@ -298,6 +298,8 @@ Tileset.prototype.getTileAnimations = function (tileId) {
                 new Phaser.Frame(i, frame.x, frame.y, frame.width, frame.height)
             );
         }
+
+        return this.tileanimations[tileId];
     }
 
     return null;


### PR DESCRIPTION
In `Tileset.prototype.getTileAnimations`, if the animation data is not found in `this.tileanimations`, it will be loaded from the `tilesData`; however in this case, `null` instead of the animation data is return, so the animation disappears for the first animated tile. The demo of this bug can be found in #72 .