### PR TITLE
Fixed Pixi Base Texture accessor

### DIFF
--- a/src/tiled/Tileset.js
+++ b/src/tiled/Tileset.js
@@ -29,7 +29,7 @@ var utils = require('../utils');
 // see: https://github.com/bjorn/tiled/wiki/TMX-Map-Format#tileset
 function Tileset(game, key, settings) {
     var txkey = utils.cacheKey(key, 'tileset', settings.name);
-    var tx = game.cache.getPixiBaseTexture(txkey);
+    var tx = game.cache.getBaseTexture(txkey);
     var ids;
     var ttxkey;
     var ttx;


### PR DESCRIPTION
With this change, the plugin now works with Phaser 2.6 and all versions of Phaser CE (tested up to 2.8.0).